### PR TITLE
Update Docker container(s) to use Debian Bookworm from Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------
 # The build container
 # -------------------
-FROM debian:buster-slim AS build
+FROM debian:bookworm-slim AS build
 
 # Install build dependencies.
 RUN apt-get update && \
@@ -44,7 +44,7 @@ RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
 # Removed numpy from this list, using system packages.
 # --no-binary numpy
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install \
-  --user --no-warn-script-location --ignore-installed \
+  --user --no-warn-script-location --ignore-installed --break-system-packages \
     crcmod \
     flask \
     flask-socketio \
@@ -63,7 +63,7 @@ RUN make
 # -------------------------
 # The application container
 # -------------------------
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 EXPOSE 5003/tcp
 


### PR DESCRIPTION
This fixes the issue below by updating to more recent system packages and pip packages on Bookworm. 

```console
2025-01-19 00:57:02,807 INFO: Uploader - Started uploader thread.
2025-01-19 00:57:02,808 INFO: Directory Watcher - Started Directory Watcher Thread.
Found Rafael Micro R820T tuner
Traceback (most recent call last):
  File "wenetserver.py", line 19, in <module>
    from flask_socketio import SocketIO
  File "/root/.local/lib/python3.7/site-packages/flask_socketio/__init__.py", line 52, in <module>
    class SocketIO:
  File "/root/.local/lib/python3.7/site-packages/flask_socketio/__init__.py", line 168, in SocketIO
    reason = socketio.Server.reason
AttributeError: type object 'Server' has no attribute 'reason'
```